### PR TITLE
Fix startup crash when journals directory missing

### DIFF
--- a/server/pointrel20150417/pointrelServer.js
+++ b/server/pointrel20150417/pointrelServer.js
@@ -215,12 +215,18 @@ function resetIndexesForJournal(journal) {
 // Loads all journals after determining identifiers from storage
 function indexAllJournals() {
     log("=================================== indexAllJournals");
-    
+
     var journalsDirectory = configuration.journalsDirectory;
-    
+
     if (!isUsingFiles()) return;
-        
-    var fileNames;
+
+    // Ensure journals directory exists so readdirSync does not fail on first run
+    if (!fs.existsSync(journalsDirectory)) {
+        fs.mkdirSync(journalsDirectory, { recursive: true });
+        log("Created journals directory: " + journalsDirectory);
+    }
+
+    var fileNames = [];
     try {
         fileNames = fs.readdirSync(journalsDirectory);
     } catch (error) {
@@ -344,8 +350,8 @@ function indexAllMessagesInDirectory(journal, directory) {
     // TODO: If files are added while reindexing is going on and reindexing takes a long time, the new files could be reject as later than this maximum
     // log("indexAllMessagesInDirectory", directory);
     var maximumAllowedTimestamp = utility.calculateMaximumAllowedTimestamp(configuration.maximumTimeDriftAllowed_ms);
-    
-    var fileNames;
+
+    var fileNames = [];
     try {
         fileNames = fs.readdirSync(directory);
     } catch(error) {


### PR DESCRIPTION
## Summary
- ensure server creates missing `server-data/journals` directory
- guard readdirSync calls so missing folders don't crash

## Testing
- `npm test` *(fails: Missing script)*
- `node -e "require('./server/pointrel20150417/pointrelServer.js');"`


------
https://chatgpt.com/codex/tasks/task_e_685d841220688330ad1b60d9dcc746a3