### PR TITLE
Integrate Supabase journal storage

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,5 +45,8 @@
   },
   "devDependencies": {
     "typescript": "2.4.2"
+  },
+  "dependencies": {
+    "@supabase/supabase-js": "^2.50.2"
   }
 }


### PR DESCRIPTION
## Summary
- add `@supabase/supabase-js` dependency
- connect to Supabase from `pointrelServer.js`
- load journals from Supabase instead of filesystem
- store new messages in Supabase
- expose helper `loadJournalByName`

## Testing
- `node --check server/pointrel20150417/pointrelServer.js`

------
https://chatgpt.com/codex/tasks/task_e_685d8d1d8e7083308c5483375a141468